### PR TITLE
ci: add reusable maintenance workflows

### DIFF
--- a/.github/workflows/contribution-quality.yml
+++ b/.github/workflows/contribution-quality.yml
@@ -1,0 +1,262 @@
+# Checks PR metadata against contribution expectations.
+#
+# Caller responsibilities:
+# - Trigger on `pull_request_target` and/or `workflow_dispatch`.
+# - Grant `contents: read`, `pull-requests: write`, and `issues: write`.
+
+name: Contribution Quality
+
+# IMPORTANT: This runs in the context of the caller repository.
+# Do NOT checkout or run code from the PR itself; only inspect PR metadata via the API.
+on:
+  workflow_call:
+    inputs:
+      pr_number:
+        description: "PR number to evaluate for manual runs"
+        required: false
+        type: string
+        default: ""
+      force_all:
+        description: "Skip trusted/draft checks"
+        required: false
+        type: string
+        default: "false"
+
+jobs:
+  gate:
+    if: >
+      github.event_name == 'workflow_dispatch' ||
+      github.event_name == 'pull_request_target'
+    runs-on: ubuntu-latest
+    env:
+      DISPATCH_PR_NUMBER: ${{ inputs.pr_number }}
+      DISPATCH_FORCE_ALL: ${{ inputs.force_all }}
+    steps:
+      - name: Resolve PR number and event mode
+        id: ctx
+        uses: actions/github-script@v7
+        with:
+          script: |
+            // pull_request_target has the same payload shape as pull_request
+            const isPREvent = !!context.payload.pull_request;
+            const fromDispatch = context.payload?.inputs?.pr_number || process.env.DISPATCH_PR_NUMBER || '';
+            const prNumber = isPREvent ? String(context.payload.pull_request.number) : String(fromDispatch || '');
+            if (!prNumber) {
+              core.setFailed('pr_number is required for manual (workflow_dispatch) runs.');
+              return;
+            }
+            const forceAll = (context.payload?.inputs?.force_all || process.env.DISPATCH_FORCE_ALL || 'false').toLowerCase();
+            core.setOutput('is_pr_event', String(isPREvent));
+            core.setOutput('pr_number', prNumber);
+            core.setOutput('force_all', forceAll);
+
+      - name: Load PR details
+        id: pr
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const prNumber = parseInt("${{ steps.ctx.outputs.pr_number }}", 10);
+            const { data: pr } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: prNumber
+            });
+            core.setOutput('author_login', pr.user?.login || '');
+            core.setOutput('draft', pr.draft ? 'true' : 'false');
+            core.setOutput('body', (pr.body || '').replace(/\r/g, ''));
+            core.setOutput('number', String(pr.number));
+
+      - name: Resolve author permission
+        id: perm
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const login = "${{ steps.pr.outputs.author_login }}".toLowerCase();
+            let permission = 'none';
+            try {
+              const { data } = await github.rest.repos.getCollaboratorPermissionLevel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                username: login,
+              });
+              permission = (data.permission || 'none').toLowerCase();
+            } catch (error) {
+              if (error.status !== 404) {
+                core.warning(`Failed to resolve collaborator permission for ${login}: ${error.message}`);
+              }
+            }
+
+            const skip = ['admin', 'maintain', 'write'].includes(permission);
+            core.info(`author=${login} permission=${permission} skip=${skip}`);
+            core.setOutput('permission', permission);
+            core.setOutput('skip', skip ? 'true' : 'false');
+
+      - name: Skip trusted authors or drafts (unless forced)
+        id: gate
+        run: |
+          draft="${{ steps.pr.outputs.draft }}"
+          force="${{ steps.ctx.outputs.force_all }}"
+          skip_by_permission="${{ steps.perm.outputs.skip }}"
+          if [ "$force" = "true" ]; then
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          else
+            [ "$skip_by_permission" = "true" ] && echo "skip=true" >> "$GITHUB_OUTPUT" || echo "skip=false" >> "$GITHUB_OUTPUT"
+            [ "$draft" = "true" ] && echo "skip=true" >> "$GITHUB_OUTPUT" || true
+          fi
+
+      - name: Evaluate
+        if: steps.gate.outputs.skip != 'true'
+        id: eval
+        uses: actions/github-script@v7
+        env:
+          PRNUM: ${{ steps.pr.outputs.number }}
+          BODY: ${{ steps.pr.outputs.body }}
+        with:
+          script: |
+            const prNumber = parseInt(process.env.PRNUM, 10);
+            const body = process.env.BODY || '';
+
+            const DOC_ONLY_MAX_LINES = 20;
+            const CODE_ONLY_MAX_LINES = 8;
+            const MAX_ISSUES_TO_CHECK = 5;
+
+            const files = await github.rest.pulls.listFiles({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: prNumber,
+              per_page: 100
+            }).then(r => r.data);
+
+            const ext = (p) => {
+              const i = p.lastIndexOf('.');
+              return i >= 0 ? p.slice(i).toLowerCase() : '';
+            };
+            const DOCS = new Set(['.md', '.rst', '.txt']);
+            const CODE = new Set(['.rs', '.go', '.py', '.ts', '.tsx', '.js', '.jsx', '.java', '.kt', '.cpp', '.c', '.hpp', '.hh', '.h', '.rb', '.swift', '.scala', '.php', '.sh', '.bash', '.zsh', '.ps1', '.yaml', '.yml', '.toml', '.json']);
+            const TEST_HINTS = [/^tests?\//i, /\/tests?\//i, /_test\./i, /\.spec\./i, /\.test\./i];
+
+            const changedFiles = files.length;
+            const adds = files.reduce((a, f) => a + (f.additions || 0), 0);
+            const dels = files.reduce((a, f) => a + (f.deletions || 0), 0);
+            const onlyDocs = changedFiles > 0 && files.every(f => DOCS.has(ext(f.filename)));
+            const onlyCode = changedFiles > 0 && files.every(f => CODE.has(ext(f.filename)));
+            const touchesTests = files.some(f => TEST_HINTS.some(rx => rx.test(f.filename)));
+
+            const issueNums = new Set();
+            for (const m of (body.match(/(?:fixe?s?|close?s?|resolve?s?)\s*#(\d+)/ig) || [])) {
+              const mm = m.match(/#(\d+)/);
+              if (mm) issueNums.add(mm[1]);
+            }
+            for (const m of (body.match(/#(\d+)/g) || [])) {
+              issueNums.add(m.replace('#', ''));
+            }
+
+            let hasLinkedIssue = false;
+            let linkedAssigned = false;
+            let linkedNumber = null;
+            if (issueNums.size) {
+              const author = (await github.rest.pulls.get({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: prNumber
+              })).data.user.login.toLowerCase();
+              for (const n of [...issueNums].slice(0, MAX_ISSUES_TO_CHECK).map(x => parseInt(x, 10)).filter(Number.isInteger)) {
+                try {
+                  const { data: iss } = await github.rest.issues.get({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: n
+                  });
+                  if (!iss.pull_request) {
+                    hasLinkedIssue = true;
+                    linkedNumber = n;
+                    const assignees = (iss.assignees || []).map(a => a.login.toLowerCase());
+                    if (assignees.includes(author)) linkedAssigned = true;
+                    break;
+                  }
+                } catch (err) {
+                  core.warning(`Failed to fetch issue #${n}: ${err}`);
+                }
+              }
+            }
+
+            const hasRationale = /(^|\n)#{0,3}\s*(rationale|why)\b/i.test(body) || /\bbecause\b/i.test(body);
+            const hasTestPlan = /(^|\n)#{0,3}\s*(test\s*plan|how\s*i\s*tested)\b/i.test(body);
+
+            const trivialDoc = onlyDocs && (adds + dels) <= DOC_ONLY_MAX_LINES && changedFiles <= 2;
+            const trivialCode = onlyCode && !touchesTests && (adds + dels) <= CODE_ONLY_MAX_LINES && changedFiles <= 1;
+
+            const findings = [];
+            const recommendations = [];
+            if (!hasLinkedIssue) findings.push('Link an issue in the PR body (e.g., "Fixes #123").');
+            else if (!linkedAssigned) findings.push(`Ensure issue #${linkedNumber} is assigned to the PR author.`);
+            if (!hasRationale) findings.push('Add a short Rationale explaining why the change is needed.');
+            if (!hasTestPlan) recommendations.push('Consider adding a Test plan or clear review steps.');
+            if (trivialDoc) findings.push('Change appears to be a trivial doc-only edit; may be batched internally.');
+            if (trivialCode) findings.push('Change appears to be a trivial code-only edit without tests; may be batched internally.');
+
+            core.setOutput('hasFindings', String(findings.length > 0));
+            core.setOutput('findings', JSON.stringify(findings));
+            core.setOutput('recommendations', JSON.stringify(recommendations));
+            core.setOutput('linked', linkedNumber ? String(linkedNumber) : '');
+            core.setOutput('pr_number', String(prNumber));
+
+      - name: Apply label and comment
+        if: steps.gate.outputs.skip != 'true' && (steps.eval.outputs.hasFindings == 'true' || steps.eval.outputs.recommendations != '[]')
+        uses: actions/github-script@v7
+        env:
+          FINDINGS: ${{ steps.eval.outputs.findings }}
+          RECOMMENDATIONS: ${{ steps.eval.outputs.recommendations }}
+          LINK: ${{ steps.eval.outputs.linked }}
+          PRNUM: ${{ steps.eval.outputs.pr_number }}
+          HAS_FINDINGS: ${{ steps.eval.outputs.hasFindings }}
+        with:
+          script: |
+            const issue_number = parseInt(process.env.PRNUM, 10);
+            const findings = JSON.parse(process.env.FINDINGS || "[]");
+            const recommendations = JSON.parse(process.env.RECOMMENDATIONS || "[]");
+            const linked = process.env.LINK;
+            const hasFindings = process.env.HAS_FINDINGS === 'true';
+
+            // Only apply label if there are actual findings (not just recommendations)
+            if (hasFindings) {
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number,
+                labels: ['quality-concern']
+              });
+            }
+
+            const guidance = [
+              linked ? `- Ensure issue #${linked} is assigned to you.` : '- Link a relevant issue (e.g., "Fixes #123") and ensure it is assigned to you.',
+              '- See CONTRIBUTING.md for expectations.',
+              '- If this is a false positive, comment: `/quality-review`.'
+            ];
+
+            const commentBody = [
+              'Automated check (CONTRIBUTING.md)',
+              ''
+            ];
+
+            if (findings.length > 0) {
+              commentBody.push('Findings:');
+              commentBody.push(...findings.map(f => `- ${f}`));
+              commentBody.push('');
+            }
+
+            if (recommendations.length > 0) {
+              commentBody.push('Recommendations:');
+              commentBody.push(...recommendations.map(f => `- ${f}`));
+              commentBody.push('');
+            }
+
+            commentBody.push('Next steps:');
+            commentBody.push(...guidance);
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number,
+              body: commentBody.join('\n')
+            });

--- a/.github/workflows/contribution-quality.yml
+++ b/.github/workflows/contribution-quality.yml
@@ -24,9 +24,6 @@ on:
 
 jobs:
   gate:
-    if: >
-      github.event_name == 'workflow_dispatch' ||
-      github.event_name == 'pull_request_target'
     runs-on: ubuntu-latest
     env:
       DISPATCH_PR_NUMBER: ${{ inputs.pr_number }}
@@ -37,7 +34,6 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            // pull_request_target has the same payload shape as pull_request
             const isPREvent = !!context.payload.pull_request;
             const fromDispatch = context.payload?.inputs?.pr_number || process.env.DISPATCH_PR_NUMBER || '';
             const prNumber = isPREvent ? String(context.payload.pull_request.number) : String(fromDispatch || '');
@@ -46,7 +42,6 @@ jobs:
               return;
             }
             const forceAll = (context.payload?.inputs?.force_all || process.env.DISPATCH_FORCE_ALL || 'false').toLowerCase();
-            core.setOutput('is_pr_event', String(isPREvent));
             core.setOutput('pr_number', prNumber);
             core.setOutput('force_all', forceAll);
 
@@ -63,6 +58,7 @@ jobs:
             });
             core.setOutput('author_login', pr.user?.login || '');
             core.setOutput('draft', pr.draft ? 'true' : 'false');
+            core.setOutput('title', (pr.title || '').replace(/\r/g, ''));
             core.setOutput('body', (pr.body || '').replace(/\r/g, ''));
             core.setOutput('number', String(pr.number));
 
@@ -110,11 +106,14 @@ jobs:
         uses: actions/github-script@v7
         env:
           PRNUM: ${{ steps.pr.outputs.number }}
+          TITLE: ${{ steps.pr.outputs.title }}
           BODY: ${{ steps.pr.outputs.body }}
         with:
           script: |
             const prNumber = parseInt(process.env.PRNUM, 10);
+            const title = process.env.TITLE || '';
             const body = process.env.BODY || '';
+            const summary = [title, body].filter(Boolean).join('\n');
 
             const DOC_ONLY_MAX_LINES = 20;
             const CODE_ONLY_MAX_LINES = 8;
@@ -142,13 +141,22 @@ jobs:
             const onlyCode = changedFiles > 0 && files.every(f => CODE.has(ext(f.filename)));
             const touchesTests = files.some(f => TEST_HINTS.some(rx => rx.test(f.filename)));
 
+            const sameRepoSlug = `${context.repo.owner}/${context.repo.repo}`.toLowerCase();
             const issueNums = new Set();
-            for (const m of (body.match(/(?:fixe?s?|close?s?|resolve?s?)\s*#(\d+)/ig) || [])) {
-              const mm = m.match(/#(\d+)/);
-              if (mm) issueNums.add(mm[1]);
+            const addIssueNumber = (repoSlug, issueNumber) => {
+              if (!issueNumber) return;
+              if (repoSlug && repoSlug.toLowerCase() !== sameRepoSlug) return;
+              issueNums.add(issueNumber);
+            };
+
+            for (const match of summary.matchAll(/https:\/\/github\.com\/([^/\s]+)\/([^/\s]+)\/issues\/(\d+)/ig)) {
+              addIssueNumber(`${match[1]}/${match[2]}`, match[3]);
             }
-            for (const m of (body.match(/#(\d+)/g) || [])) {
-              issueNums.add(m.replace('#', ''));
+            for (const match of summary.matchAll(/\b([A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+)#(\d+)\b/g)) {
+              addIssueNumber(match[1], match[2]);
+            }
+            for (const match of summary.matchAll(/(^|[^\w/])#(\d+)\b/gm)) {
+              addIssueNumber(sameRepoSlug, match[2]);
             }
 
             let hasLinkedIssue = false;
@@ -180,8 +188,8 @@ jobs:
               }
             }
 
-            const hasRationale = /(^|\n)#{0,3}\s*(rationale|why)\b/i.test(body) || /\bbecause\b/i.test(body);
-            const hasTestPlan = /(^|\n)#{0,3}\s*(test\s*plan|how\s*i\s*tested)\b/i.test(body);
+            const hasRationale = /(^|\n)#{0,3}\s*(rationale|why)\b/i.test(summary) || /\bbecause\b/i.test(summary);
+            const hasTestPlan = /(^|\n)#{0,3}\s*(test\s*plan|how\s*i\s*tested)\b/i.test(summary);
 
             const trivialDoc = onlyDocs && (adds + dels) <= DOC_ONLY_MAX_LINES && changedFiles <= 2;
             const trivialCode = onlyCode && !touchesTests && (adds + dels) <= CODE_ONLY_MAX_LINES && changedFiles <= 1;
@@ -201,24 +209,41 @@ jobs:
             core.setOutput('linked', linkedNumber ? String(linkedNumber) : '');
             core.setOutput('pr_number', String(prNumber));
 
-      - name: Apply label and comment
-        if: steps.gate.outputs.skip != 'true' && (steps.eval.outputs.hasFindings == 'true' || steps.eval.outputs.recommendations != '[]')
+      - name: Sync label and comment
+        if: always() && steps.ctx.outputs.pr_number != ''
         uses: actions/github-script@v7
         env:
+          SKIP: ${{ steps.gate.outputs.skip }}
           FINDINGS: ${{ steps.eval.outputs.findings }}
           RECOMMENDATIONS: ${{ steps.eval.outputs.recommendations }}
           LINK: ${{ steps.eval.outputs.linked }}
-          PRNUM: ${{ steps.eval.outputs.pr_number }}
+          PRNUM: ${{ steps.ctx.outputs.pr_number }}
           HAS_FINDINGS: ${{ steps.eval.outputs.hasFindings }}
         with:
           script: |
             const issue_number = parseInt(process.env.PRNUM, 10);
+            const skip = process.env.SKIP === 'true';
             const findings = JSON.parse(process.env.FINDINGS || "[]");
             const recommendations = JSON.parse(process.env.RECOMMENDATIONS || "[]");
             const linked = process.env.LINK;
             const hasFindings = process.env.HAS_FINDINGS === 'true';
+            const shouldComment = !skip && (findings.length > 0 || recommendations.length > 0);
+            const marker = '<!-- contribution-quality-comment -->';
+            const legacyHeader = 'Automated check (CONTRIBUTING.md)';
 
-            // Only apply label if there are actual findings (not just recommendations)
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number,
+              per_page: 100
+            });
+            const existingComment = comments
+              .filter((comment) => {
+                const body = comment.body || '';
+                return comment.user?.type === 'Bot' && (body.includes(marker) || body.startsWith(legacyHeader));
+              })
+              .sort((left, right) => Date.parse(right.updated_at) - Date.parse(left.updated_at))[0];
+
             if (hasFindings) {
               await github.rest.issues.addLabels({
                 owner: context.repo.owner,
@@ -226,6 +251,30 @@ jobs:
                 issue_number,
                 labels: ['quality-concern']
               });
+            } else {
+              try {
+                await github.rest.issues.removeLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number,
+                  name: 'quality-concern'
+                });
+              } catch (error) {
+                if (error.status !== 404) {
+                  throw error;
+                }
+              }
+            }
+
+            if (!shouldComment) {
+              if (existingComment) {
+                await github.rest.issues.deleteComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  comment_id: existingComment.id
+                });
+              }
+              return;
             }
 
             const guidance = [
@@ -235,28 +284,43 @@ jobs:
             ];
 
             const commentBody = [
+              marker,
               'Automated check (CONTRIBUTING.md)',
               ''
             ];
 
             if (findings.length > 0) {
               commentBody.push('Findings:');
-              commentBody.push(...findings.map(f => `- ${f}`));
+              commentBody.push(...findings.map((finding) => `- ${finding}`));
               commentBody.push('');
             }
 
             if (recommendations.length > 0) {
               commentBody.push('Recommendations:');
-              commentBody.push(...recommendations.map(f => `- ${f}`));
+              commentBody.push(...recommendations.map((recommendation) => `- ${recommendation}`));
               commentBody.push('');
             }
 
             commentBody.push('Next steps:');
             commentBody.push(...guidance);
 
+            const bodyText = commentBody.join('\n');
+
+            if (existingComment) {
+              if (existingComment.body !== bodyText) {
+                await github.rest.issues.updateComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  comment_id: existingComment.id,
+                  body: bodyText
+                });
+              }
+              return;
+            }
+
             await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number,
-              body: commentBody.join('\n')
+              body: bodyText
             });

--- a/.github/workflows/signed-commits.yml
+++ b/.github/workflows/signed-commits.yml
@@ -1,7 +1,7 @@
 # Verifies that all commits in a PR are signed (GPG or SSH).
 # Caller responsibilities:
 # - Trigger on `pull_request_target`.
-# - Grant `contents: read` and `pull-requests: write`.
+# - Grant `contents: read` and `issues: write`.
 
 name: signed commits
 
@@ -18,6 +18,8 @@ jobs:
         with:
           script: |
             const prNumber = context.payload.pull_request.number;
+            core.setOutput('pr_number', String(prNumber));
+
             const commits = await github.rest.pulls.listCommits({
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -38,14 +40,13 @@ jobs:
             );
 
             core.setOutput('unsigned', lines.join('\n'));
-            core.setOutput('pr_number', String(prNumber));
             core.setFailed(
               `Found ${unsigned.length} unsigned commit(s) in this PR. ` +
               'All commits must be signed (GPG or SSH).'
             );
 
-      - name: Comment with remediation steps
-        if: failure() && steps.check.outputs.unsigned != ''
+      - name: Sync remediation comment
+        if: always() && steps.check.outputs.pr_number != ''
         uses: actions/github-script@v7
         env:
           UNSIGNED: ${{ steps.check.outputs.unsigned }}
@@ -54,8 +55,35 @@ jobs:
           script: |
             const issue_number = parseInt(process.env.PRNUM, 10);
             const unsignedList = process.env.UNSIGNED;
+            const marker = '<!-- signed-commits-comment -->';
+            const legacyHeader = 'This PR contains unsigned commits. All commits must be cryptographically signed (GPG or SSH).';
+
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number,
+              per_page: 100
+            });
+            const existingComment = comments
+              .filter((comment) => {
+                const body = comment.body || '';
+                return comment.user?.type === 'Bot' && (body.includes(marker) || body.startsWith(legacyHeader));
+              })
+              .sort((left, right) => Date.parse(right.updated_at) - Date.parse(left.updated_at))[0];
+
+            if (!unsignedList) {
+              if (existingComment) {
+                await github.rest.issues.deleteComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  comment_id: existingComment.id
+                });
+              }
+              return;
+            }
 
             const body = [
+              marker,
               'This PR contains unsigned commits. All commits must be cryptographically signed (GPG or SSH).',
               '',
               'Unsigned commits:',
@@ -64,6 +92,18 @@ jobs:
               'For instructions on setting up commit signing and re-signing existing commits, see:',
               'https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits'
             ].join('\n');
+
+            if (existingComment) {
+              if (existingComment.body !== body) {
+                await github.rest.issues.updateComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  comment_id: existingComment.id,
+                  body
+                });
+              }
+              return;
+            }
 
             await github.rest.issues.createComment({
               owner: context.repo.owner,

--- a/.github/workflows/signed-commits.yml
+++ b/.github/workflows/signed-commits.yml
@@ -1,0 +1,73 @@
+# Verifies that all commits in a PR are signed (GPG or SSH).
+# Caller responsibilities:
+# - Trigger on `pull_request_target`.
+# - Grant `contents: read` and `pull-requests: write`.
+
+name: signed commits
+
+on:
+  workflow_call:
+
+jobs:
+  check-signed-commits:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check for unsigned commits
+        id: check
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const prNumber = context.payload.pull_request.number;
+            const commits = await github.rest.pulls.listCommits({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: prNumber,
+              per_page: 250
+            });
+
+            const unsigned = commits.data.filter(c => !c.commit.verification.verified);
+
+            if (unsigned.length === 0) {
+              core.setOutput('unsigned', '');
+              core.info('All commits are signed.');
+              return;
+            }
+
+            const lines = unsigned.map(c =>
+              `- \`${c.sha.slice(0, 8)}\` ${c.commit.message.split('\n')[0]}`
+            );
+
+            core.setOutput('unsigned', lines.join('\n'));
+            core.setOutput('pr_number', String(prNumber));
+            core.setFailed(
+              `Found ${unsigned.length} unsigned commit(s) in this PR. ` +
+              'All commits must be signed (GPG or SSH).'
+            );
+
+      - name: Comment with remediation steps
+        if: failure() && steps.check.outputs.unsigned != ''
+        uses: actions/github-script@v7
+        env:
+          UNSIGNED: ${{ steps.check.outputs.unsigned }}
+          PRNUM: ${{ steps.check.outputs.pr_number }}
+        with:
+          script: |
+            const issue_number = parseInt(process.env.PRNUM, 10);
+            const unsignedList = process.env.UNSIGNED;
+
+            const body = [
+              'This PR contains unsigned commits. All commits must be cryptographically signed (GPG or SSH).',
+              '',
+              'Unsigned commits:',
+              unsignedList,
+              '',
+              'For instructions on setting up commit signing and re-signing existing commits, see:',
+              'https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits'
+            ].join('\n');
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number,
+              body
+            });


### PR DESCRIPTION
This adds the check for signed commits from https://github.com/0xMiden/miden-vm/pull/2930
And the check for contrib quality from https://github.com/0xMiden/miden-vm/pull/2542 https://github.com/0xMiden/miden-vm/pull/2956

Downstream: https://github.com/0xMiden/crypto/pull/928