### PR TITLE
ci: harden reusable maintenance workflows

### DIFF
--- a/.github/workflows/contribution-quality.yml
+++ b/.github/workflows/contribution-quality.yml
@@ -119,12 +119,12 @@ jobs:
             const CODE_ONLY_MAX_LINES = 8;
             const MAX_ISSUES_TO_CHECK = 5;
 
-            const files = await github.rest.pulls.listFiles({
+            const allFiles = await github.paginate(github.rest.pulls.listFiles, {
               owner: context.repo.owner,
               repo: context.repo.repo,
               pull_number: prNumber,
               per_page: 100
-            }).then(r => r.data);
+            });
 
             const ext = (p) => {
               const i = p.lastIndexOf('.');
@@ -134,12 +134,12 @@ jobs:
             const CODE = new Set(['.rs', '.go', '.py', '.ts', '.tsx', '.js', '.jsx', '.java', '.kt', '.cpp', '.c', '.hpp', '.hh', '.h', '.rb', '.swift', '.scala', '.php', '.sh', '.bash', '.zsh', '.ps1', '.yaml', '.yml', '.toml', '.json']);
             const TEST_HINTS = [/^tests?\//i, /\/tests?\//i, /_test\./i, /\.spec\./i, /\.test\./i];
 
-            const changedFiles = files.length;
-            const adds = files.reduce((a, f) => a + (f.additions || 0), 0);
-            const dels = files.reduce((a, f) => a + (f.deletions || 0), 0);
-            const onlyDocs = changedFiles > 0 && files.every(f => DOCS.has(ext(f.filename)));
-            const onlyCode = changedFiles > 0 && files.every(f => CODE.has(ext(f.filename)));
-            const touchesTests = files.some(f => TEST_HINTS.some(rx => rx.test(f.filename)));
+            const changedFiles = allFiles.length;
+            const adds = allFiles.reduce((a, f) => a + (f.additions || 0), 0);
+            const dels = allFiles.reduce((a, f) => a + (f.deletions || 0), 0);
+            const onlyDocs = changedFiles > 0 && allFiles.every(f => DOCS.has(ext(f.filename)));
+            const onlyCode = changedFiles > 0 && allFiles.every(f => CODE.has(ext(f.filename)));
+            const touchesTests = allFiles.some(f => TEST_HINTS.some(rx => rx.test(f.filename)));
 
             const sameRepoSlug = `${context.repo.owner}/${context.repo.repo}`.toLowerCase();
             const issueNums = new Set();
@@ -208,12 +208,14 @@ jobs:
             core.setOutput('recommendations', JSON.stringify(recommendations));
             core.setOutput('linked', linkedNumber ? String(linkedNumber) : '');
             core.setOutput('pr_number', String(prNumber));
+            core.setOutput('completed', 'true');
 
       - name: Sync label and comment
         if: always() && steps.ctx.outputs.pr_number != ''
         uses: actions/github-script@v7
         env:
           SKIP: ${{ steps.gate.outputs.skip }}
+          EVAL_COMPLETED: ${{ steps.eval.outputs.completed }}
           FINDINGS: ${{ steps.eval.outputs.findings }}
           RECOMMENDATIONS: ${{ steps.eval.outputs.recommendations }}
           LINK: ${{ steps.eval.outputs.linked }}
@@ -223,10 +225,15 @@ jobs:
           script: |
             const issue_number = parseInt(process.env.PRNUM, 10);
             const skip = process.env.SKIP === 'true';
+            const evalCompleted = process.env.EVAL_COMPLETED === 'true';
             const findings = JSON.parse(process.env.FINDINGS || "[]");
             const recommendations = JSON.parse(process.env.RECOMMENDATIONS || "[]");
             const linked = process.env.LINK;
             const hasFindings = process.env.HAS_FINDINGS === 'true';
+            if (!skip && !evalCompleted) {
+              core.warning('Contribution-quality evaluation did not complete; leaving existing label and comment untouched.');
+              return;
+            }
             const shouldComment = !skip && (findings.length > 0 || recommendations.length > 0);
             const marker = '<!-- contribution-quality-comment -->';
             const legacyHeader = 'Automated check (CONTRIBUTING.md)';

--- a/.github/workflows/signed-commits.yml
+++ b/.github/workflows/signed-commits.yml
@@ -18,28 +18,28 @@ jobs:
         with:
           script: |
             const prNumber = context.payload.pull_request.number;
-            core.setOutput('pr_number', String(prNumber));
-
-            const commits = await github.rest.pulls.listCommits({
+            const commits = await github.paginate(github.rest.pulls.listCommits, {
               owner: context.repo.owner,
               repo: context.repo.repo,
               pull_number: prNumber,
-              per_page: 250
+              per_page: 100
             });
 
-            const unsigned = commits.data.filter(c => !c.commit.verification.verified);
+            const unsigned = commits.filter(c => !c.commit.verification.verified);
 
             if (unsigned.length === 0) {
+              core.setOutput('pr_number', String(prNumber));
               core.setOutput('unsigned', '');
+              core.setOutput('completed', 'true');
               core.info('All commits are signed.');
               return;
             }
 
-            const lines = unsigned.map(c =>
-              `- \`${c.sha.slice(0, 8)}\` ${c.commit.message.split('\n')[0]}`
-            );
+            const lines = unsigned.map(c => `- \`${c.sha.slice(0, 8)}\``);
 
+            core.setOutput('pr_number', String(prNumber));
             core.setOutput('unsigned', lines.join('\n'));
+            core.setOutput('completed', 'true');
             core.setFailed(
               `Found ${unsigned.length} unsigned commit(s) in this PR. ` +
               'All commits must be signed (GPG or SSH).'
@@ -49,14 +49,21 @@ jobs:
         if: always() && steps.check.outputs.pr_number != ''
         uses: actions/github-script@v7
         env:
+          COMPLETED: ${{ steps.check.outputs.completed }}
           UNSIGNED: ${{ steps.check.outputs.unsigned }}
           PRNUM: ${{ steps.check.outputs.pr_number }}
         with:
           script: |
             const issue_number = parseInt(process.env.PRNUM, 10);
+            const checkCompleted = process.env.COMPLETED === 'true';
             const unsignedList = process.env.UNSIGNED;
             const marker = '<!-- signed-commits-comment -->';
             const legacyHeader = 'This PR contains unsigned commits. All commits must be cryptographically signed (GPG or SSH).';
+
+            if (!checkCompleted) {
+              core.warning('Signed-commit check did not complete; leaving any existing remediation comment untouched.');
+              return;
+            }
 
             const comments = await github.paginate(github.rest.issues.listComments, {
               owner: context.repo.owner,


### PR DESCRIPTION
The workflows now read all changed files and all PR commits, so large PRs are checked fully. They also keep existing bot comments and labels when a check fails partway through, instead of clearing them by mistake. The signed-commit comment now shows only commit SHAs.