### PR TITLE
ci: Add reusable workspace release workflow

### DIFF
--- a/.github/actions/cleanup-runner/action.yml
+++ b/.github/actions/cleanup-runner/action.yml
@@ -1,5 +1,5 @@
 name: Cleanup Runner
-description: Remove unused tools in the runner image to free disk space
+description: Remove unused tools from GitHub-hosted Ubuntu runners to free disk space
 
 runs:
   using: composite
@@ -7,6 +7,21 @@ runs:
     - name: Remove unused tools in the runner image
       shell: bash
       run: |
+        if [ "${RUNNER_OS:-}" != "Linux" ]; then
+          echo "::error::cleanup-runner only supports Linux runners."
+          exit 1
+        fi
+
+        if [ "${RUNNER_ENVIRONMENT:-}" != "github-hosted" ]; then
+          echo "::error::cleanup-runner only supports GitHub-hosted runners."
+          exit 1
+        fi
+
+        if ! command -v apt-get >/dev/null 2>&1; then
+          echo "::error::cleanup-runner expects an Ubuntu-based runner with apt-get."
+          exit 1
+        fi
+
         echo "=== Cleaning up GitHub Actions runner to free disk space ==="
         sudo rm -rf /usr/share/dotnet /usr/local/lib/android
         sudo docker system prune -af --volumes || true

--- a/.github/actions/cleanup-runner/action.yml
+++ b/.github/actions/cleanup-runner/action.yml
@@ -1,0 +1,16 @@
+name: Cleanup Runner
+description: Remove unused tools in the runner image to free disk space
+
+runs:
+  using: composite
+  steps:
+    - name: Remove unused tools in the runner image
+      shell: bash
+      run: |
+        echo "=== Cleaning up GitHub Actions runner to free disk space ==="
+        sudo rm -rf /usr/share/dotnet /usr/local/lib/android
+        sudo docker system prune -af --volumes || true
+        sudo apt-get remove -y '^ghc-.*' '^php.*' '^mongodb.*' '^mysql.*' '^postgresql.*' || true
+        sudo apt-get autoremove -y || true
+        sudo apt-get clean || true
+        df -h

--- a/.github/workflows/workspace-release.yml
+++ b/.github/workflows/workspace-release.yml
@@ -78,9 +78,10 @@ jobs:
           fi
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # pin@v4
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Resolve shared workflow source
         id: shared_workflow_source
@@ -95,12 +96,13 @@ jobs:
           echo "sha=$WORKFLOW_SHA" >> "$GITHUB_OUTPUT"
 
       - name: Checkout shared workflow repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # pin@v4
         with:
           repository: ${{ steps.shared_workflow_source.outputs.repository }}
           ref: ${{ steps.shared_workflow_source.outputs.sha }}
           path: .shared-workflows
           fetch-depth: 1
+          persist-credentials: false
           token: ${{ env.SHARED_WORKFLOW_REPOSITORY_TOKEN_INPUT != '' && env.SHARED_WORKFLOW_REPOSITORY_TOKEN_INPUT || github.token }}
 
       - name: Verify checked out commit matches target ref HEAD
@@ -123,13 +125,13 @@ jobs:
           fi
 
       - name: Install Rust toolchain
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@150fca883cd4034361b621bd4e6a9d34e5143606 # pin@v1
         with:
           cache: false
           rustflags: ""
 
       - name: Cache cargo registry and git index
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # pin@v4
         with:
           path: |
             ~/.cargo/registry
@@ -142,7 +144,7 @@ jobs:
         uses: ./.shared-workflows/.github/actions/cleanup-runner
 
       - name: Install cargo-binstall
-        uses: taiki-e/install-action@v2
+        uses: taiki-e/install-action@b8be7f5e140177087325943c4a8e169d01c59b3d # pin@v2
         with:
           tool: cargo-binstall
 
@@ -170,7 +172,9 @@ jobs:
 
       - name: Install Rust toolchain for cargo-msrv
         shell: bash
-        run: rustup toolchain install "${{ steps.resolve_cargo_msrv_toolchain.outputs.toolchain }}"
+        env:
+          CARGO_MSRV_TOOLCHAIN: ${{ steps.resolve_cargo_msrv_toolchain.outputs.toolchain }}
+        run: rustup toolchain install "$CARGO_MSRV_TOOLCHAIN"
 
       - name: Check MSRV
         shell: bash
@@ -194,7 +198,7 @@ jobs:
         id: semver_checks
         if: ${{ inputs.mode == 'dry-run' || inputs.mode == 'publish' }}
         continue-on-error: ${{ inputs.mode == 'publish' }}
-        uses: obi1kenobi/cargo-semver-checks-action@v2
+        uses: obi1kenobi/cargo-semver-checks-action@6b69fcf40e9b5fb17adeb57e4b6ecd020649a239 # pin@v2
         with:
           rust-toolchain: manual
 
@@ -219,7 +223,7 @@ jobs:
       - name: Authenticate with crates.io
         if: ${{ inputs.mode == 'publish' }}
         id: crates-io-auth
-        uses: rust-lang/crates-io-auth-action@v1
+        uses: rust-lang/crates-io-auth-action@b7e9a28eded4986ec6b1fa40eeee8f8f165559ec # pin@v1
 
       - name: Dry-run workspace publish
         if: ${{ inputs.mode == 'dry-run' }}
@@ -262,9 +266,10 @@ jobs:
           fi
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # pin@v4
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Resolve shared workflow source
         id: shared_workflow_source
@@ -279,12 +284,13 @@ jobs:
           echo "sha=$WORKFLOW_SHA" >> "$GITHUB_OUTPUT"
 
       - name: Checkout shared workflow repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # pin@v4
         with:
           repository: ${{ steps.shared_workflow_source.outputs.repository }}
           ref: ${{ steps.shared_workflow_source.outputs.sha }}
           path: .shared-workflows
           fetch-depth: 1
+          persist-credentials: false
           token: ${{ env.SHARED_WORKFLOW_REPOSITORY_TOKEN_INPUT != '' && env.SHARED_WORKFLOW_REPOSITORY_TOKEN_INPUT || github.token }}
 
       - name: Verify checked out commit matches target ref HEAD
@@ -307,13 +313,13 @@ jobs:
           fi
 
       - name: Install Rust toolchain
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@150fca883cd4034361b621bd4e6a9d34e5143606 # pin@v1
         with:
           cache: false
           rustflags: ""
 
       - name: Cache cargo registry and git index
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # pin@v4
         with:
           path: |
             ~/.cargo/registry
@@ -326,7 +332,7 @@ jobs:
         uses: ./.shared-workflows/.github/actions/cleanup-runner
 
       - name: Install cargo-binstall
-        uses: taiki-e/install-action@v2
+        uses: taiki-e/install-action@b8be7f5e140177087325943c4a8e169d01c59b3d # pin@v2
         with:
           tool: cargo-binstall
 
@@ -354,7 +360,9 @@ jobs:
 
       - name: Install Rust toolchain for cargo-msrv
         shell: bash
-        run: rustup toolchain install "${{ steps.resolve_cargo_msrv_toolchain.outputs.toolchain }}"
+        env:
+          CARGO_MSRV_TOOLCHAIN: ${{ steps.resolve_cargo_msrv_toolchain.outputs.toolchain }}
+        run: rustup toolchain install "$CARGO_MSRV_TOOLCHAIN"
 
       - name: Check MSRV
         shell: bash
@@ -378,7 +386,7 @@ jobs:
         id: semver_checks
         if: ${{ inputs.mode == 'dry-run' || inputs.mode == 'publish' }}
         continue-on-error: ${{ inputs.mode == 'publish' }}
-        uses: obi1kenobi/cargo-semver-checks-action@v2
+        uses: obi1kenobi/cargo-semver-checks-action@6b69fcf40e9b5fb17adeb57e4b6ecd020649a239 # pin@v2
         with:
           rust-toolchain: manual
 
@@ -403,7 +411,7 @@ jobs:
       - name: Authenticate with crates.io
         if: ${{ inputs.mode == 'publish' }}
         id: crates-io-auth
-        uses: rust-lang/crates-io-auth-action@v1
+        uses: rust-lang/crates-io-auth-action@b7e9a28eded4986ec6b1fa40eeee8f8f165559ec # pin@v1
 
       - name: Dry-run workspace publish
         if: ${{ inputs.mode == 'dry-run' }}

--- a/.github/workflows/workspace-release.yml
+++ b/.github/workflows/workspace-release.yml
@@ -79,6 +79,25 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Resolve shared workflow source
+        id: shared_workflow_source
+        shell: bash
+        run: |
+          workflow_ref="${{ github.workflow_ref }}"
+          repository="${workflow_ref%%/.github/workflows/*}"
+          ref="${workflow_ref##*@}"
+
+          echo "repository=$repository" >> "$GITHUB_OUTPUT"
+          echo "ref=$ref" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout shared workflow repository
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ steps.shared_workflow_source.outputs.repository }}
+          ref: ${{ steps.shared_workflow_source.outputs.ref }}
+          path: .shared-workflows
+          fetch-depth: 1
+
       - name: Verify checked out commit matches target ref HEAD
         if: ${{ inputs.verify_target_ref_head }}
         shell: bash
@@ -113,15 +132,7 @@ jobs:
             ${{ runner.os }}-cargo-
 
       - name: Cleanup large tools for build space
-        shell: bash
-        run: |
-          echo "=== Cleaning up GitHub Actions runner to free disk space ==="
-          sudo rm -rf /usr/share/dotnet /usr/local/lib/android
-          sudo docker system prune -af --volumes || true
-          sudo apt-get remove -y '^ghc-.*' '^php.*' '^mongodb.*' '^mysql.*' '^postgresql.*' || true
-          sudo apt-get autoremove -y || true
-          sudo apt-get clean || true
-          df -h
+        uses: ./.shared-workflows/.github/actions/cleanup-runner
 
       - name: Install cargo-binstall
         uses: taiki-e/install-action@v2
@@ -252,6 +263,25 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Resolve shared workflow source
+        id: shared_workflow_source
+        shell: bash
+        run: |
+          workflow_ref="${{ github.workflow_ref }}"
+          repository="${workflow_ref%%/.github/workflows/*}"
+          ref="${workflow_ref##*@}"
+
+          echo "repository=$repository" >> "$GITHUB_OUTPUT"
+          echo "ref=$ref" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout shared workflow repository
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ steps.shared_workflow_source.outputs.repository }}
+          ref: ${{ steps.shared_workflow_source.outputs.ref }}
+          path: .shared-workflows
+          fetch-depth: 1
+
       - name: Verify checked out commit matches target ref HEAD
         if: ${{ inputs.verify_target_ref_head }}
         shell: bash
@@ -286,15 +316,7 @@ jobs:
             ${{ runner.os }}-cargo-
 
       - name: Cleanup large tools for build space
-        shell: bash
-        run: |
-          echo "=== Cleaning up GitHub Actions runner to free disk space ==="
-          sudo rm -rf /usr/share/dotnet /usr/local/lib/android
-          sudo docker system prune -af --volumes || true
-          sudo apt-get remove -y '^ghc-.*' '^php.*' '^mongodb.*' '^mysql.*' '^postgresql.*' || true
-          sudo apt-get autoremove -y || true
-          sudo apt-get clean || true
-          df -h
+        uses: ./.shared-workflows/.github/actions/cleanup-runner
 
       - name: Install cargo-binstall
         uses: taiki-e/install-action@v2

--- a/.github/workflows/workspace-release.yml
+++ b/.github/workflows/workspace-release.yml
@@ -44,6 +44,9 @@ on:
       cargo_registry_token:
         description: "Optional crates.io token. If omitted, OIDC auth is used for publish mode."
         required: false
+      shared_workflow_repository_token:
+        description: "Optional token for checking out the shared workflow repository when it is private or internal."
+        required: false
 
 permissions:
   contents: read
@@ -56,20 +59,24 @@ jobs:
     runs-on: ubuntu-latest
     env:
       CARGO_REGISTRY_TOKEN_INPUT: ${{ secrets.cargo_registry_token }}
+      SHARED_WORKFLOW_REPOSITORY_TOKEN_INPUT: ${{ secrets.shared_workflow_repository_token }}
 
     steps:
       - name: Validate inputs
         shell: bash
+        env:
+          MODE: ${{ inputs.mode }}
+          ENVIRONMENT_NAME: ${{ inputs.environment_name }}
         run: |
-          case "${{ inputs.mode }}" in
+          case "$MODE" in
             dry-run|publish) ;;
             *)
-              echo "::error::Unsupported mode '${{ inputs.mode }}'. Expected 'dry-run' or 'publish'."
+              echo "::error::Unsupported mode '$MODE'. Expected 'dry-run' or 'publish'."
               exit 1
               ;;
           esac
 
-          if [ "${{ inputs.mode }}" = "publish" ] && [ -z "${{ inputs.environment_name }}" ]; then
+          if [ "$MODE" = "publish" ] && [ -z "$ENVIRONMENT_NAME" ]; then
             echo "::error::Publish mode requires environment_name so crates.io trusted publishing can run through a protected environment."
             exit 1
           fi
@@ -82,36 +89,40 @@ jobs:
       - name: Resolve shared workflow source
         id: shared_workflow_source
         shell: bash
+        env:
+          WORKFLOW_REF: ${{ github.workflow_ref }}
+          WORKFLOW_SHA: ${{ github.workflow_sha }}
         run: |
-          workflow_ref="${{ github.workflow_ref }}"
-          repository="${workflow_ref%%/.github/workflows/*}"
-          ref="${workflow_ref##*@}"
+          repository="${WORKFLOW_REF%%/.github/workflows/*}"
 
           echo "repository=$repository" >> "$GITHUB_OUTPUT"
-          echo "ref=$ref" >> "$GITHUB_OUTPUT"
+          echo "sha=$WORKFLOW_SHA" >> "$GITHUB_OUTPUT"
 
       - name: Checkout shared workflow repository
         uses: actions/checkout@v4
         with:
           repository: ${{ steps.shared_workflow_source.outputs.repository }}
-          ref: ${{ steps.shared_workflow_source.outputs.ref }}
+          ref: ${{ steps.shared_workflow_source.outputs.sha }}
           path: .shared-workflows
           fetch-depth: 1
+          token: ${{ env.SHARED_WORKFLOW_REPOSITORY_TOKEN_INPUT != '' && env.SHARED_WORKFLOW_REPOSITORY_TOKEN_INPUT || github.token }}
 
       - name: Verify checked out commit matches target ref HEAD
         if: ${{ inputs.verify_target_ref_head }}
         shell: bash
+        env:
+          TARGET_REF: ${{ inputs.target_ref }}
         run: |
-          git fetch origin "${{ inputs.target_ref }}" --depth=1
-          target_sha="$(git rev-parse "origin/${{ inputs.target_ref }}")"
+          git fetch origin "$TARGET_REF" --depth=1
+          target_sha="$(git rev-parse "origin/$TARGET_REF")"
           checkout_sha="$(git rev-parse HEAD)"
 
-          echo "target_ref=${{ inputs.target_ref }}"
+          echo "target_ref=$TARGET_REF"
           echo "target_sha=$target_sha"
           echo "checkout_sha=$checkout_sha"
 
           if [ "$target_sha" != "$checkout_sha" ]; then
-            echo "::error::The checked out commit does not match origin/${{ inputs.target_ref }} HEAD. Aborting."
+            echo "::error::The checked out commit does not match origin/$TARGET_REF HEAD. Aborting."
             exit 1
           fi
 
@@ -142,8 +153,10 @@ jobs:
       - name: Resolve cargo-msrv toolchain
         id: resolve_cargo_msrv_toolchain
         shell: bash
+        env:
+          CARGO_MSRV_TOOLCHAIN_INPUT: ${{ inputs.cargo_msrv_toolchain }}
         run: |
-          toolchain="${{ inputs.cargo_msrv_toolchain }}"
+          toolchain="$CARGO_MSRV_TOOLCHAIN_INPUT"
           if [ -z "$toolchain" ]; then
             toolchain="$(rustup show active-toolchain | awk '{print $1}')"
           fi
@@ -167,14 +180,15 @@ jobs:
         shell: bash
         env:
           RUSTUP_TOOLCHAIN: ${{ steps.resolve_cargo_msrv_toolchain.outputs.toolchain }}
+          MSRV_SCRIPT_PATH: ${{ inputs.msrv_script_path }}
         run: |
-          if [ ! -f "${{ inputs.msrv_script_path }}" ]; then
-            echo "::error::MSRV script not found at '${{ inputs.msrv_script_path }}'."
+          if [ ! -f "$MSRV_SCRIPT_PATH" ]; then
+            echo "::error::MSRV script not found at '$MSRV_SCRIPT_PATH'."
             exit 1
           fi
 
           export PATH="$HOME/.cargo/bin:$PATH"
-          bash "${{ inputs.msrv_script_path }}"
+          bash "$MSRV_SCRIPT_PATH"
 
       - name: Clean packaging directory
         shell: bash
@@ -229,8 +243,6 @@ jobs:
       - name: Publish workspace crates
         if: ${{ inputs.mode == 'publish' }}
         shell: bash
-        env:
-          CARGO_REGISTRY_TOKEN: ${{ env.CARGO_REGISTRY_TOKEN }}
         run: cargo publish --workspace
 
   workspace-release-with-environment:
@@ -240,20 +252,24 @@ jobs:
     environment: ${{ inputs.environment_name }}
     env:
       CARGO_REGISTRY_TOKEN_INPUT: ${{ secrets.cargo_registry_token }}
+      SHARED_WORKFLOW_REPOSITORY_TOKEN_INPUT: ${{ secrets.shared_workflow_repository_token }}
 
     steps:
       - name: Validate inputs
         shell: bash
+        env:
+          MODE: ${{ inputs.mode }}
+          ENVIRONMENT_NAME: ${{ inputs.environment_name }}
         run: |
-          case "${{ inputs.mode }}" in
+          case "$MODE" in
             dry-run|publish) ;;
             *)
-              echo "::error::Unsupported mode '${{ inputs.mode }}'. Expected 'dry-run' or 'publish'."
+              echo "::error::Unsupported mode '$MODE'. Expected 'dry-run' or 'publish'."
               exit 1
               ;;
           esac
 
-          if [ "${{ inputs.mode }}" = "publish" ] && [ -z "${{ inputs.environment_name }}" ]; then
+          if [ "$MODE" = "publish" ] && [ -z "$ENVIRONMENT_NAME" ]; then
             echo "::error::Publish mode requires environment_name so crates.io trusted publishing can run through a protected environment."
             exit 1
           fi
@@ -266,36 +282,40 @@ jobs:
       - name: Resolve shared workflow source
         id: shared_workflow_source
         shell: bash
+        env:
+          WORKFLOW_REF: ${{ github.workflow_ref }}
+          WORKFLOW_SHA: ${{ github.workflow_sha }}
         run: |
-          workflow_ref="${{ github.workflow_ref }}"
-          repository="${workflow_ref%%/.github/workflows/*}"
-          ref="${workflow_ref##*@}"
+          repository="${WORKFLOW_REF%%/.github/workflows/*}"
 
           echo "repository=$repository" >> "$GITHUB_OUTPUT"
-          echo "ref=$ref" >> "$GITHUB_OUTPUT"
+          echo "sha=$WORKFLOW_SHA" >> "$GITHUB_OUTPUT"
 
       - name: Checkout shared workflow repository
         uses: actions/checkout@v4
         with:
           repository: ${{ steps.shared_workflow_source.outputs.repository }}
-          ref: ${{ steps.shared_workflow_source.outputs.ref }}
+          ref: ${{ steps.shared_workflow_source.outputs.sha }}
           path: .shared-workflows
           fetch-depth: 1
+          token: ${{ env.SHARED_WORKFLOW_REPOSITORY_TOKEN_INPUT != '' && env.SHARED_WORKFLOW_REPOSITORY_TOKEN_INPUT || github.token }}
 
       - name: Verify checked out commit matches target ref HEAD
         if: ${{ inputs.verify_target_ref_head }}
         shell: bash
+        env:
+          TARGET_REF: ${{ inputs.target_ref }}
         run: |
-          git fetch origin "${{ inputs.target_ref }}" --depth=1
-          target_sha="$(git rev-parse "origin/${{ inputs.target_ref }}")"
+          git fetch origin "$TARGET_REF" --depth=1
+          target_sha="$(git rev-parse "origin/$TARGET_REF")"
           checkout_sha="$(git rev-parse HEAD)"
 
-          echo "target_ref=${{ inputs.target_ref }}"
+          echo "target_ref=$TARGET_REF"
           echo "target_sha=$target_sha"
           echo "checkout_sha=$checkout_sha"
 
           if [ "$target_sha" != "$checkout_sha" ]; then
-            echo "::error::The checked out commit does not match origin/${{ inputs.target_ref }} HEAD. Aborting."
+            echo "::error::The checked out commit does not match origin/$TARGET_REF HEAD. Aborting."
             exit 1
           fi
 
@@ -326,8 +346,10 @@ jobs:
       - name: Resolve cargo-msrv toolchain
         id: resolve_cargo_msrv_toolchain
         shell: bash
+        env:
+          CARGO_MSRV_TOOLCHAIN_INPUT: ${{ inputs.cargo_msrv_toolchain }}
         run: |
-          toolchain="${{ inputs.cargo_msrv_toolchain }}"
+          toolchain="$CARGO_MSRV_TOOLCHAIN_INPUT"
           if [ -z "$toolchain" ]; then
             toolchain="$(rustup show active-toolchain | awk '{print $1}')"
           fi
@@ -351,14 +373,15 @@ jobs:
         shell: bash
         env:
           RUSTUP_TOOLCHAIN: ${{ steps.resolve_cargo_msrv_toolchain.outputs.toolchain }}
+          MSRV_SCRIPT_PATH: ${{ inputs.msrv_script_path }}
         run: |
-          if [ ! -f "${{ inputs.msrv_script_path }}" ]; then
-            echo "::error::MSRV script not found at '${{ inputs.msrv_script_path }}'."
+          if [ ! -f "$MSRV_SCRIPT_PATH" ]; then
+            echo "::error::MSRV script not found at '$MSRV_SCRIPT_PATH'."
             exit 1
           fi
 
           export PATH="$HOME/.cargo/bin:$PATH"
-          bash "${{ inputs.msrv_script_path }}"
+          bash "$MSRV_SCRIPT_PATH"
 
       - name: Clean packaging directory
         shell: bash
@@ -413,6 +436,4 @@ jobs:
       - name: Publish workspace crates
         if: ${{ inputs.mode == 'publish' }}
         shell: bash
-        env:
-          CARGO_REGISTRY_TOKEN: ${{ env.CARGO_REGISTRY_TOKEN }}
         run: cargo publish --workspace

--- a/.github/workflows/workspace-release.yml
+++ b/.github/workflows/workspace-release.yml
@@ -41,9 +41,6 @@ on:
         default: ""
 
     secrets:
-      cargo_registry_token:
-        description: "Optional crates.io token. If omitted, OIDC auth is used for publish mode."
-        required: false
       shared_workflow_repository_token:
         description: "Optional token for checking out the shared workflow repository when it is private or internal."
         required: false
@@ -58,7 +55,6 @@ jobs:
     name: Workspace release (${{ inputs.mode }})
     runs-on: ubuntu-latest
     env:
-      CARGO_REGISTRY_TOKEN_INPUT: ${{ secrets.cargo_registry_token }}
       SHARED_WORKFLOW_REPOSITORY_TOKEN_INPUT: ${{ secrets.shared_workflow_repository_token }}
 
     steps:
@@ -220,20 +216,10 @@ jobs:
         shell: bash
         run: rm -rf ~/.cargo/registry/{cache,index,src}
 
-      - name: Use provided crates.io token
-        if: ${{ inputs.mode == 'publish' && env.CARGO_REGISTRY_TOKEN_INPUT != '' }}
-        shell: bash
-        run: echo "CARGO_REGISTRY_TOKEN=${CARGO_REGISTRY_TOKEN_INPUT}" >> "$GITHUB_ENV"
-
       - name: Authenticate with crates.io
-        if: ${{ inputs.mode == 'publish' && env.CARGO_REGISTRY_TOKEN_INPUT == '' }}
+        if: ${{ inputs.mode == 'publish' }}
         id: crates-io-auth
         uses: rust-lang/crates-io-auth-action@v1
-
-      - name: Export crates.io token from OIDC auth
-        if: ${{ inputs.mode == 'publish' && env.CARGO_REGISTRY_TOKEN_INPUT == '' }}
-        shell: bash
-        run: echo "CARGO_REGISTRY_TOKEN=${{ steps.crates-io-auth.outputs.token }}" >> "$GITHUB_ENV"
 
       - name: Dry-run workspace publish
         if: ${{ inputs.mode == 'dry-run' }}
@@ -243,6 +229,8 @@ jobs:
       - name: Publish workspace crates
         if: ${{ inputs.mode == 'publish' }}
         shell: bash
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.crates-io-auth.outputs.token }}
         run: cargo publish --workspace
 
   workspace-release-with-environment:
@@ -251,7 +239,6 @@ jobs:
     runs-on: ubuntu-latest
     environment: ${{ inputs.environment_name }}
     env:
-      CARGO_REGISTRY_TOKEN_INPUT: ${{ secrets.cargo_registry_token }}
       SHARED_WORKFLOW_REPOSITORY_TOKEN_INPUT: ${{ secrets.shared_workflow_repository_token }}
 
     steps:
@@ -413,20 +400,10 @@ jobs:
         shell: bash
         run: rm -rf ~/.cargo/registry/{cache,index,src}
 
-      - name: Use provided crates.io token
-        if: ${{ inputs.mode == 'publish' && env.CARGO_REGISTRY_TOKEN_INPUT != '' }}
-        shell: bash
-        run: echo "CARGO_REGISTRY_TOKEN=${CARGO_REGISTRY_TOKEN_INPUT}" >> "$GITHUB_ENV"
-
       - name: Authenticate with crates.io
-        if: ${{ inputs.mode == 'publish' && env.CARGO_REGISTRY_TOKEN_INPUT == '' }}
+        if: ${{ inputs.mode == 'publish' }}
         id: crates-io-auth
         uses: rust-lang/crates-io-auth-action@v1
-
-      - name: Export crates.io token from OIDC auth
-        if: ${{ inputs.mode == 'publish' && env.CARGO_REGISTRY_TOKEN_INPUT == '' }}
-        shell: bash
-        run: echo "CARGO_REGISTRY_TOKEN=${{ steps.crates-io-auth.outputs.token }}" >> "$GITHUB_ENV"
 
       - name: Dry-run workspace publish
         if: ${{ inputs.mode == 'dry-run' }}
@@ -436,4 +413,6 @@ jobs:
       - name: Publish workspace crates
         if: ${{ inputs.mode == 'publish' }}
         shell: bash
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.crates-io-auth.outputs.token }}
         run: cargo publish --workspace

--- a/.github/workflows/workspace-release.yml
+++ b/.github/workflows/workspace-release.yml
@@ -26,10 +26,10 @@ on:
         type: string
         default: "main"
       cargo_msrv_toolchain:
-        description: "Rust toolchain used to run cargo-msrv"
+        description: "Rust toolchain used to run cargo-msrv. If unset, use the caller repo toolchain."
         required: false
         type: string
-        default: "1.91"
+        default: ""
       msrv_script_path:
         description: "Path to the caller repository script that checks workspace MSRV"
         required: true
@@ -128,18 +128,34 @@ jobs:
         with:
           tool: cargo-binstall
 
+      - name: Resolve cargo-msrv toolchain
+        id: resolve_cargo_msrv_toolchain
+        shell: bash
+        run: |
+          toolchain="${{ inputs.cargo_msrv_toolchain }}"
+          if [ -z "$toolchain" ]; then
+            toolchain="$(rustup show active-toolchain | awk '{print $1}')"
+          fi
+
+          if [ -z "$toolchain" ]; then
+            echo "::error::Could not resolve a toolchain for cargo-msrv."
+            exit 1
+          fi
+
+          echo "toolchain=$toolchain" >> "$GITHUB_OUTPUT"
+
       - name: Install cargo-msrv
         shell: bash
         run: cargo binstall --no-confirm --force cargo-msrv
 
       - name: Install Rust toolchain for cargo-msrv
         shell: bash
-        run: rustup toolchain install "${{ inputs.cargo_msrv_toolchain }}"
+        run: rustup toolchain install "${{ steps.resolve_cargo_msrv_toolchain.outputs.toolchain }}"
 
       - name: Check MSRV
         shell: bash
         env:
-          RUSTUP_TOOLCHAIN: ${{ inputs.cargo_msrv_toolchain }}
+          RUSTUP_TOOLCHAIN: ${{ steps.resolve_cargo_msrv_toolchain.outputs.toolchain }}
         run: |
           if [ ! -f "${{ inputs.msrv_script_path }}" ]; then
             echo "::error::MSRV script not found at '${{ inputs.msrv_script_path }}'."
@@ -285,18 +301,34 @@ jobs:
         with:
           tool: cargo-binstall
 
+      - name: Resolve cargo-msrv toolchain
+        id: resolve_cargo_msrv_toolchain
+        shell: bash
+        run: |
+          toolchain="${{ inputs.cargo_msrv_toolchain }}"
+          if [ -z "$toolchain" ]; then
+            toolchain="$(rustup show active-toolchain | awk '{print $1}')"
+          fi
+
+          if [ -z "$toolchain" ]; then
+            echo "::error::Could not resolve a toolchain for cargo-msrv."
+            exit 1
+          fi
+
+          echo "toolchain=$toolchain" >> "$GITHUB_OUTPUT"
+
       - name: Install cargo-msrv
         shell: bash
         run: cargo binstall --no-confirm --force cargo-msrv
 
       - name: Install Rust toolchain for cargo-msrv
         shell: bash
-        run: rustup toolchain install "${{ inputs.cargo_msrv_toolchain }}"
+        run: rustup toolchain install "${{ steps.resolve_cargo_msrv_toolchain.outputs.toolchain }}"
 
       - name: Check MSRV
         shell: bash
         env:
-          RUSTUP_TOOLCHAIN: ${{ inputs.cargo_msrv_toolchain }}
+          RUSTUP_TOOLCHAIN: ${{ steps.resolve_cargo_msrv_toolchain.outputs.toolchain }}
         run: |
           if [ ! -f "${{ inputs.msrv_script_path }}" ]; then
             echo "::error::MSRV script not found at '${{ inputs.msrv_script_path }}'."

--- a/.github/workflows/workspace-release.yml
+++ b/.github/workflows/workspace-release.yml
@@ -25,11 +25,6 @@ on:
         required: false
         type: string
         default: "main"
-      rust_toolchain:
-        description: "Rust toolchain used for cargo publish"
-        required: false
-        type: string
-        default: "1.90"
       cargo_msrv_toolchain:
         description: "Rust toolchain used to run cargo-msrv"
         required: false
@@ -40,15 +35,10 @@ on:
         required: true
         type: string
       environment_name:
-        description: "Optional caller-repository environment name for protected releases"
+        description: "Protected environment name. Required in publish mode."
         required: false
         type: string
         default: ""
-      cleanup_runner:
-        description: "Remove large preinstalled runner tools before packaging"
-        required: false
-        type: boolean
-        default: true
 
     secrets:
       cargo_registry_token:
@@ -79,6 +69,11 @@ jobs:
               ;;
           esac
 
+          if [ "${{ inputs.mode }}" = "publish" ] && [ -z "${{ inputs.environment_name }}" ]; then
+            echo "::error::Publish mode requires environment_name so crates.io trusted publishing can run through a protected environment."
+            exit 1
+          fi
+
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
@@ -102,9 +97,10 @@ jobs:
           fi
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          toolchain: ${{ inputs.rust_toolchain }}
+          cache: false
+          rustflags: ""
 
       - name: Cache cargo registry and git index
         uses: actions/cache@v4
@@ -117,7 +113,6 @@ jobs:
             ${{ runner.os }}-cargo-
 
       - name: Cleanup large tools for build space
-        if: ${{ inputs.cleanup_runner }}
         shell: bash
         run: |
           echo "=== Cleaning up GitHub Actions runner to free disk space ==="
@@ -163,6 +158,8 @@ jobs:
         if: ${{ inputs.mode == 'dry-run' || inputs.mode == 'publish' }}
         continue-on-error: ${{ inputs.mode == 'publish' }}
         uses: obi1kenobi/cargo-semver-checks-action@v2
+        with:
+          rust-toolchain: manual
 
       - name: Report semver check failure
         if: ${{ inputs.mode == 'publish' && steps.semver_checks.outcome == 'failure' }}
@@ -229,6 +226,11 @@ jobs:
               ;;
           esac
 
+          if [ "${{ inputs.mode }}" = "publish" ] && [ -z "${{ inputs.environment_name }}" ]; then
+            echo "::error::Publish mode requires environment_name so crates.io trusted publishing can run through a protected environment."
+            exit 1
+          fi
+
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
@@ -252,9 +254,10 @@ jobs:
           fi
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          toolchain: ${{ inputs.rust_toolchain }}
+          cache: false
+          rustflags: ""
 
       - name: Cache cargo registry and git index
         uses: actions/cache@v4
@@ -267,7 +270,6 @@ jobs:
             ${{ runner.os }}-cargo-
 
       - name: Cleanup large tools for build space
-        if: ${{ inputs.cleanup_runner }}
         shell: bash
         run: |
           echo "=== Cleaning up GitHub Actions runner to free disk space ==="
@@ -313,6 +315,8 @@ jobs:
         if: ${{ inputs.mode == 'dry-run' || inputs.mode == 'publish' }}
         continue-on-error: ${{ inputs.mode == 'publish' }}
         uses: obi1kenobi/cargo-semver-checks-action@v2
+        with:
+          rust-toolchain: manual
 
       - name: Report semver check failure
         if: ${{ inputs.mode == 'publish' && steps.semver_checks.outcome == 'failure' }}

--- a/.github/workflows/workspace-release.yml
+++ b/.github/workflows/workspace-release.yml
@@ -1,0 +1,324 @@
+# Reusable Rust workspace release workflow.
+#
+# Caller responsibilities:
+# - Trigger the caller workflow for the desired events (for example push and release).
+# - Grant `contents: read` and `id-token: write` permissions.
+# - Keep the MSRV verification script in the caller repository and pass its path via
+#   `msrv_script_path`.
+
+name: Workspace release
+
+on:
+  workflow_call:
+    inputs:
+      mode:
+        description: "Release mode: dry-run or publish"
+        required: true
+        type: string
+      verify_target_ref_head:
+        description: "Ensure the checked out commit matches the HEAD of target_ref"
+        required: false
+        type: boolean
+        default: false
+      target_ref:
+        description: "Branch to compare against when verify_target_ref_head is enabled"
+        required: false
+        type: string
+        default: "main"
+      rust_toolchain:
+        description: "Rust toolchain used for cargo publish"
+        required: false
+        type: string
+        default: "1.90"
+      cargo_msrv_toolchain:
+        description: "Rust toolchain used to run cargo-msrv"
+        required: false
+        type: string
+        default: "1.91"
+      msrv_script_path:
+        description: "Path to the caller repository script that checks workspace MSRV"
+        required: true
+        type: string
+      environment_name:
+        description: "Optional caller-repository environment name for protected releases"
+        required: false
+        type: string
+        default: ""
+      cleanup_runner:
+        description: "Remove large preinstalled runner tools before packaging"
+        required: false
+        type: boolean
+        default: true
+
+    secrets:
+      cargo_registry_token:
+        description: "Optional crates.io token. If omitted, OIDC auth is used for publish mode."
+        required: false
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  workspace-release:
+    if: ${{ inputs.environment_name == '' }}
+    name: Workspace release (${{ inputs.mode }})
+    runs-on: ubuntu-latest
+    env:
+      CARGO_REGISTRY_TOKEN_INPUT: ${{ secrets.cargo_registry_token }}
+
+    steps:
+      - name: Validate inputs
+        shell: bash
+        run: |
+          case "${{ inputs.mode }}" in
+            dry-run|publish) ;;
+            *)
+              echo "::error::Unsupported mode '${{ inputs.mode }}'. Expected 'dry-run' or 'publish'."
+              exit 1
+              ;;
+          esac
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Verify checked out commit matches target ref HEAD
+        if: ${{ inputs.verify_target_ref_head }}
+        shell: bash
+        run: |
+          git fetch origin "${{ inputs.target_ref }}" --depth=1
+          target_sha="$(git rev-parse "origin/${{ inputs.target_ref }}")"
+          checkout_sha="$(git rev-parse HEAD)"
+
+          echo "target_ref=${{ inputs.target_ref }}"
+          echo "target_sha=$target_sha"
+          echo "checkout_sha=$checkout_sha"
+
+          if [ "$target_sha" != "$checkout_sha" ]; then
+            echo "::error::The checked out commit does not match origin/${{ inputs.target_ref }} HEAD. Aborting."
+            exit 1
+          fi
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: ${{ inputs.rust_toolchain }}
+
+      - name: Cache cargo registry and git index
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+
+      - name: Cleanup large tools for build space
+        if: ${{ inputs.cleanup_runner }}
+        shell: bash
+        run: |
+          echo "=== Cleaning up GitHub Actions runner to free disk space ==="
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android
+          sudo docker system prune -af --volumes || true
+          sudo apt-get remove -y '^ghc-.*' '^php.*' '^mongodb.*' '^mysql.*' '^postgresql.*' || true
+          sudo apt-get autoremove -y || true
+          sudo apt-get clean || true
+          df -h
+
+      - name: Install cargo-binstall
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-binstall
+
+      - name: Install cargo-msrv
+        shell: bash
+        run: cargo binstall --no-confirm --force cargo-msrv
+
+      - name: Install Rust toolchain for cargo-msrv
+        shell: bash
+        run: rustup toolchain install "${{ inputs.cargo_msrv_toolchain }}"
+
+      - name: Check MSRV
+        shell: bash
+        env:
+          RUSTUP_TOOLCHAIN: ${{ inputs.cargo_msrv_toolchain }}
+        run: |
+          if [ ! -f "${{ inputs.msrv_script_path }}" ]; then
+            echo "::error::MSRV script not found at '${{ inputs.msrv_script_path }}'."
+            exit 1
+          fi
+
+          export PATH="$HOME/.cargo/bin:$PATH"
+          bash "${{ inputs.msrv_script_path }}"
+
+      - name: Clean packaging directory
+        shell: bash
+        run: rm -rf target/package
+
+      # Workaround for cargo#14283 and cargo#14789.
+      - name: Clear cargo registry
+        if: ${{ inputs.mode == 'dry-run' }}
+        shell: bash
+        run: rm -rf ~/.cargo/registry/{cache,index,src}
+
+      - name: Use provided crates.io token
+        if: ${{ inputs.mode == 'publish' && env.CARGO_REGISTRY_TOKEN_INPUT != '' }}
+        shell: bash
+        run: echo "CARGO_REGISTRY_TOKEN=${CARGO_REGISTRY_TOKEN_INPUT}" >> "$GITHUB_ENV"
+
+      - name: Authenticate with crates.io
+        if: ${{ inputs.mode == 'publish' && env.CARGO_REGISTRY_TOKEN_INPUT == '' }}
+        id: crates-io-auth
+        uses: rust-lang/crates-io-auth-action@v1
+
+      - name: Export crates.io token from OIDC auth
+        if: ${{ inputs.mode == 'publish' && env.CARGO_REGISTRY_TOKEN_INPUT == '' }}
+        shell: bash
+        run: echo "CARGO_REGISTRY_TOKEN=${{ steps.crates-io-auth.outputs.token }}" >> "$GITHUB_ENV"
+
+      - name: Dry-run workspace publish
+        if: ${{ inputs.mode == 'dry-run' }}
+        shell: bash
+        run: cargo publish --workspace --dry-run
+
+      - name: Publish workspace crates
+        if: ${{ inputs.mode == 'publish' }}
+        shell: bash
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ env.CARGO_REGISTRY_TOKEN }}
+        run: cargo publish --workspace
+
+  workspace-release-with-environment:
+    if: ${{ inputs.environment_name != '' }}
+    name: Workspace release (${{ inputs.mode }})
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.environment_name }}
+    env:
+      CARGO_REGISTRY_TOKEN_INPUT: ${{ secrets.cargo_registry_token }}
+
+    steps:
+      - name: Validate inputs
+        shell: bash
+        run: |
+          case "${{ inputs.mode }}" in
+            dry-run|publish) ;;
+            *)
+              echo "::error::Unsupported mode '${{ inputs.mode }}'. Expected 'dry-run' or 'publish'."
+              exit 1
+              ;;
+          esac
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Verify checked out commit matches target ref HEAD
+        if: ${{ inputs.verify_target_ref_head }}
+        shell: bash
+        run: |
+          git fetch origin "${{ inputs.target_ref }}" --depth=1
+          target_sha="$(git rev-parse "origin/${{ inputs.target_ref }}")"
+          checkout_sha="$(git rev-parse HEAD)"
+
+          echo "target_ref=${{ inputs.target_ref }}"
+          echo "target_sha=$target_sha"
+          echo "checkout_sha=$checkout_sha"
+
+          if [ "$target_sha" != "$checkout_sha" ]; then
+            echo "::error::The checked out commit does not match origin/${{ inputs.target_ref }} HEAD. Aborting."
+            exit 1
+          fi
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: ${{ inputs.rust_toolchain }}
+
+      - name: Cache cargo registry and git index
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+
+      - name: Cleanup large tools for build space
+        if: ${{ inputs.cleanup_runner }}
+        shell: bash
+        run: |
+          echo "=== Cleaning up GitHub Actions runner to free disk space ==="
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android
+          sudo docker system prune -af --volumes || true
+          sudo apt-get remove -y '^ghc-.*' '^php.*' '^mongodb.*' '^mysql.*' '^postgresql.*' || true
+          sudo apt-get autoremove -y || true
+          sudo apt-get clean || true
+          df -h
+
+      - name: Install cargo-binstall
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-binstall
+
+      - name: Install cargo-msrv
+        shell: bash
+        run: cargo binstall --no-confirm --force cargo-msrv
+
+      - name: Install Rust toolchain for cargo-msrv
+        shell: bash
+        run: rustup toolchain install "${{ inputs.cargo_msrv_toolchain }}"
+
+      - name: Check MSRV
+        shell: bash
+        env:
+          RUSTUP_TOOLCHAIN: ${{ inputs.cargo_msrv_toolchain }}
+        run: |
+          if [ ! -f "${{ inputs.msrv_script_path }}" ]; then
+            echo "::error::MSRV script not found at '${{ inputs.msrv_script_path }}'."
+            exit 1
+          fi
+
+          export PATH="$HOME/.cargo/bin:$PATH"
+          bash "${{ inputs.msrv_script_path }}"
+
+      - name: Clean packaging directory
+        shell: bash
+        run: rm -rf target/package
+
+      # Workaround for cargo#14283 and cargo#14789.
+      - name: Clear cargo registry
+        if: ${{ inputs.mode == 'dry-run' }}
+        shell: bash
+        run: rm -rf ~/.cargo/registry/{cache,index,src}
+
+      - name: Use provided crates.io token
+        if: ${{ inputs.mode == 'publish' && env.CARGO_REGISTRY_TOKEN_INPUT != '' }}
+        shell: bash
+        run: echo "CARGO_REGISTRY_TOKEN=${CARGO_REGISTRY_TOKEN_INPUT}" >> "$GITHUB_ENV"
+
+      - name: Authenticate with crates.io
+        if: ${{ inputs.mode == 'publish' && env.CARGO_REGISTRY_TOKEN_INPUT == '' }}
+        id: crates-io-auth
+        uses: rust-lang/crates-io-auth-action@v1
+
+      - name: Export crates.io token from OIDC auth
+        if: ${{ inputs.mode == 'publish' && env.CARGO_REGISTRY_TOKEN_INPUT == '' }}
+        shell: bash
+        run: echo "CARGO_REGISTRY_TOKEN=${{ steps.crates-io-auth.outputs.token }}" >> "$GITHUB_ENV"
+
+      - name: Dry-run workspace publish
+        if: ${{ inputs.mode == 'dry-run' }}
+        shell: bash
+        run: cargo publish --workspace --dry-run
+
+      - name: Publish workspace crates
+        if: ${{ inputs.mode == 'publish' }}
+        shell: bash
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ env.CARGO_REGISTRY_TOKEN }}
+        run: cargo publish --workspace

--- a/.github/workflows/workspace-release.yml
+++ b/.github/workflows/workspace-release.yml
@@ -158,6 +158,24 @@ jobs:
         shell: bash
         run: rm -rf target/package
 
+      - name: Check public API semver compatibility
+        id: semver_checks
+        if: ${{ inputs.mode == 'dry-run' || inputs.mode == 'publish' }}
+        continue-on-error: ${{ inputs.mode == 'publish' }}
+        uses: obi1kenobi/cargo-semver-checks-action@v2
+
+      - name: Report semver check failure
+        if: ${{ inputs.mode == 'publish' && steps.semver_checks.outcome == 'failure' }}
+        shell: bash
+        run: |
+          echo "::warning::cargo-semver-checks reported a possible semver regression. Publish mode continues by design; review the semver-checks logs above."
+          {
+            echo "## Semver Check Warning"
+            echo ""
+            echo "cargo-semver-checks reported a possible semver regression during publish mode."
+            echo "The release continued by design. Review the semver-checks logs before treating this release as semver-compatible."
+          } >> "$GITHUB_STEP_SUMMARY"
+
       # Workaround for cargo#14283 and cargo#14789.
       - name: Clear cargo registry
         if: ${{ inputs.mode == 'dry-run' }}
@@ -289,6 +307,24 @@ jobs:
       - name: Clean packaging directory
         shell: bash
         run: rm -rf target/package
+
+      - name: Check public API semver compatibility
+        id: semver_checks
+        if: ${{ inputs.mode == 'dry-run' || inputs.mode == 'publish' }}
+        continue-on-error: ${{ inputs.mode == 'publish' }}
+        uses: obi1kenobi/cargo-semver-checks-action@v2
+
+      - name: Report semver check failure
+        if: ${{ inputs.mode == 'publish' && steps.semver_checks.outcome == 'failure' }}
+        shell: bash
+        run: |
+          echo "::warning::cargo-semver-checks reported a possible semver regression. Publish mode continues by design; review the semver-checks logs above."
+          {
+            echo "## Semver Check Warning"
+            echo ""
+            echo "cargo-semver-checks reported a possible semver regression during publish mode."
+            echo "The release continued by design. Review the semver-checks logs before treating this release as semver-compatible."
+          } >> "$GITHUB_STEP_SUMMARY"
 
       # Workaround for cargo#14283 and cargo#14789.
       - name: Clear cargo registry

--- a/.github/workflows/workspace-release.yml
+++ b/.github/workflows/workspace-release.yml
@@ -40,11 +40,6 @@ on:
         type: string
         default: ""
 
-    secrets:
-      shared_workflow_repository_token:
-        description: "Optional token for checking out the shared workflow repository when it is private or internal."
-        required: false
-
 permissions:
   contents: read
   id-token: write
@@ -54,8 +49,6 @@ jobs:
     if: ${{ inputs.environment_name == '' }}
     name: Workspace release (${{ inputs.mode }})
     runs-on: ubuntu-latest
-    env:
-      SHARED_WORKFLOW_REPOSITORY_TOKEN_INPUT: ${{ secrets.shared_workflow_repository_token }}
 
     steps:
       - name: Validate inputs
@@ -103,7 +96,6 @@ jobs:
           path: .shared-workflows
           fetch-depth: 1
           persist-credentials: false
-          token: ${{ env.SHARED_WORKFLOW_REPOSITORY_TOKEN_INPUT != '' && env.SHARED_WORKFLOW_REPOSITORY_TOKEN_INPUT || github.token }}
 
       - name: Verify checked out commit matches target ref HEAD
         if: ${{ inputs.verify_target_ref_head }}
@@ -242,8 +234,6 @@ jobs:
     name: Workspace release (${{ inputs.mode }})
     runs-on: ubuntu-latest
     environment: ${{ inputs.environment_name }}
-    env:
-      SHARED_WORKFLOW_REPOSITORY_TOKEN_INPUT: ${{ secrets.shared_workflow_repository_token }}
 
     steps:
       - name: Validate inputs
@@ -291,7 +281,6 @@ jobs:
           path: .shared-workflows
           fetch-depth: 1
           persist-credentials: false
-          token: ${{ env.SHARED_WORKFLOW_REPOSITORY_TOKEN_INPUT != '' && env.SHARED_WORKFLOW_REPOSITORY_TOKEN_INPUT || github.token }}
 
       - name: Verify checked out commit matches target ref HEAD
         if: ${{ inputs.verify_target_ref_head }}


### PR DESCRIPTION
This adds a shared workflow for Rust workspace releases.

Callers must pass the path to their MSRV check script. The workflow runs MSRV checks, semver checks, and then the release flow.

Dry-run treats semver regressions as failures. Publish reports them as warnings but still publishes.

Usage PR at https://github.com/0xMiden/crypto/pull/938

Pinned the shared workspace release workflow’s third-party actions to commit SHAs and disabled checkout credential persistence where no push access is needed.
